### PR TITLE
Add missing patch int32 into int64

### DIFF
--- a/docker/install_deps
+++ b/docker/install_deps
@@ -18,6 +18,7 @@ then
 fi
 
 cd openfisca-core
+sed -i s/int32/int64/ openfisca_core/variables/config.py
 sed -i s/float32/float64/ openfisca_core/variables/config.py
 sed -i s/float32/float64/ openfisca_core/tools/__init__.py
 sed -i s/float32/float64/ tests/core/tools/test_runner/test_yaml_runner.py

--- a/openfisca_pf/tests/daf/rch/edge_case.yaml
+++ b/openfisca_pf/tests/daf/rch/edge_case.yaml
@@ -1,0 +1,16 @@
+- name: 1 - Overflow int32 - valeur égale de int32 max (int32 max = 2 147 483 647)
+  period: 2025-01-16
+  input:
+    type_demarche_rch: Baux
+    valeur_locative_bien: 2147483647
+    duree_bail_mois: 1
+  output:
+    montant_droit_enregistrement: 21474836
+- name: 2 - Overflow int32 - valeur au dessus de int32 max (int32 max = 2 147 483 647)
+  period: 2025-01-16
+  input:
+    type_demarche_rch: Baux
+    valeur_locative_bien: 2147483899
+    duree_bail_mois: 1
+  output:
+    montant_droit_enregistrement: 21474839


### PR DESCRIPTION
Add missing patch for int32 into int64 when installing the dependences in the docker image